### PR TITLE
iOS is not returning same data as Android.

### DIFF
--- a/src/nativescript-google-login.ios.ts
+++ b/src/nativescript-google-login.ios.ts
@@ -55,6 +55,8 @@ export class GoogleLogin extends Common {
             invokeLoginCallbackForGoogle({
                 authCode: result.authCode,
                 code: LoginResultType.Success,
+                firstName: result.firstName,
+                lastName: result.lastName,                
                 displayName: result.displayName,
                 photo: result.photo,
                 error: result.error,
@@ -160,7 +162,7 @@ export class GoogleLogin extends Common {
                             lastName: user.profile.familyName,
                             displayName: user.profile.name,
                             photo: user.profile.imageURLWithDimension(100),
-                            authCode: user.serverAuthCode
+                            authCode: GoogleLogin.Config.google.isRequestAuthCode
                                 ? user.serverAuthCode
                                 : user.authentication.idToken,
                             id: user.userID


### PR DESCRIPTION
Missing are firstName and lastName, and there is no way to get idToken, regardless if one sets isRequestAuthCode to true or false.
This fixes all three issues.